### PR TITLE
perf: add scroll bar for zoomed session

### DIFF
--- a/ui/src/views/ConnectView.vue
+++ b/ui/src/views/ConnectView.vue
@@ -403,7 +403,10 @@ const isRemoteApp = computed(() => {
     <div
       id="display"
       v-show="!loading"
-      class="w-screen h-screen flex justify-center relative"
+      :class="[
+        'w-screen h-screen flex justify-start items-start relative',
+        scale > 1 ? 'overflow-auto' : 'overflow-hidden',
+      ]"
     ></div>
     <Osk v-if="showOsk" :keyboard="keyboardLayout" @keyboard-change="handleScreenKeyboard" />
   </div>

--- a/ui/src/views/ConnectView.vue
+++ b/ui/src/views/ConnectView.vue
@@ -358,6 +358,12 @@ const scaleGuaDisplay = (value: number) => {
   console.log('Scaling Guacamole display to:', value);
   const newScale = value / 100; // 限制缩放范围在0.1到5之间
 
+// 只要是加号放大就显示滚动条
+  if (newScale > scale.value) {
+    shouldEnableScroll.value = true;
+  } else if (newScale <= 1) {
+    shouldEnableScroll.value = false;
+  }
   guaDisplay.value.scale(newScale);
   scale.value = newScale;
 };
@@ -392,6 +398,9 @@ const isRemoteApp = computed(() => {
   }
   return true;
 });
+
+// 滚动条控制
+const shouldEnableScroll = ref(false);
 </script>
 
 <template>
@@ -404,8 +413,8 @@ const isRemoteApp = computed(() => {
       id="display"
       v-show="!loading"
       :class="[
-        'w-screen h-screen flex justify-start items-start relative',
-        scale > 1 ? 'overflow-auto' : 'overflow-hidden',
+        'w-screen h-screen flex justify-center relative',
+        shouldEnableScroll ? 'overflow-auto' : 'overflow-hidden',
       ]"
     ></div>
     <Osk v-if="showOsk" :keyboard="keyboardLayout" @keyboard-change="handleScreenKeyboard" />


### PR DESCRIPTION
![QQ20260402-132921](https://github.com/user-attachments/assets/e6f80aeb-6852-4814-8fe4-797cd1156d20)

在 Luna 连接大分辨率资产时，Lion 画面在被放大后会超出可视区域，原先容器不会按需提供横向和纵向滚动，导致用户看不到画面其余区域。

- 调整了远程显示容器的布局对齐方式为左上对齐
- 动态判断当前缩放比例，如果大于 1 显示滚动条，小于 1 隐藏