### PR TITLE
fix: Use sessionId instead of userId to prevent path traversal

### DIFF
--- a/pkg/session/configuration.go
+++ b/pkg/session/configuration.go
@@ -117,7 +117,7 @@ func (r RDPConfiguration) GetGuacdConfiguration() guacd.Configuration {
 
 	// 设置 挂载目录 上传下载
 	{
-		drivePath := filepath.Join(config.GlobalConfig.DrivePath, r.User.ID)
+		drivePath := filepath.Join(config.GlobalConfig.DrivePath, r.SessionId)
 		enableDrive := ConvertBoolToString(r.ActionsPerm.EnableDownload || r.ActionsPerm.EnableUpload)
 		disableDownload := ConvertBoolToString(!r.ActionsPerm.EnableDownload)
 		disableUpload := ConvertBoolToString(!r.ActionsPerm.EnableUpload)


### PR DESCRIPTION
当用户同时连接Windows机器A与Windows机器B时存在可能的权限逃逸问题，此提交将原先基于用户ID生成共享盘修改为基于会话ID

具体问题表现：
机器A仅有文件上传权限，机器B有所有权限
用户可以通过将机器A的文件放入共享盘，并在机器B中操作拖入Download文件触发文件下载即可成功在没有机器A的下载权限时发起文件下载