### PR TITLE
feat: add fine-grained clipboard permission control for graphical sessions

### DIFF
--- a/pkg/session/permisson.go
+++ b/pkg/session/permisson.go
@@ -1,20 +1,10 @@
 package session
 
 import (
-	"encoding/json"
 	"lion/pkg/config"
 
 	"github.com/jumpserver-dev/sdk-go/model"
 )
-
-type ClipboardPolicy struct {
-	FileUpload         bool `json:"file_upload"`
-	FileDownload       bool `json:"file_download"`
-	TextCopy           bool `json:"text_copy"`
-	TextPaste          bool `json:"text_paste"`
-	TextCopyMaxLength  int  `json:"text_copy_max_length"`
-	TextPasteMaxLength int  `json:"text_paste_max_length"`
-}
 
 type ActionPermission struct {
 	EnableConnect bool `json:"enable_connect"`
@@ -26,7 +16,7 @@ type ActionPermission struct {
 	EnableDownload bool `json:"enable_download"`
 	EnableShare    bool `json:"enable_share"`
 
-	ClipboardPolicy ClipboardPolicy `json:"clipboard_policy"`
+	ClipboardPolicy model.ClipboardPolicy `json:"clipboard_policy"`
 }
 
 func NewActionPermission(perm *model.Permission, connectType string, connectOptions model.ConnectOptions) *ActionPermission {
@@ -37,7 +27,7 @@ func NewActionPermission(perm *model.Permission, connectType string, connectOpti
 		EnableUpload:   perm.EnableUpload(),
 		EnableDownload: perm.EnableDownload(),
 		EnableShare:    perm.EnableShare(),
-		ClipboardPolicy: ClipboardPolicy{
+		ClipboardPolicy: model.ClipboardPolicy{
 			FileUpload:   true,
 			FileDownload: true,
 			TextCopy:     true,
@@ -70,13 +60,10 @@ func NewActionPermission(perm *model.Permission, connectType string, connectOpti
 }
 
 func (a *ActionPermission) applyClipboardPolicy(connectOptions model.ConnectOptions) {
-	if connectOptions.Language == "" {
+	if connectOptions.ClipboardPolicy == nil {
 		return
 	}
-	var policy ClipboardPolicy
-	if err := json.Unmarshal([]byte(connectOptions.Language), &policy); err != nil {
-		return
-	}
+	policy := *connectOptions.ClipboardPolicy
 	a.ClipboardPolicy = policy
 	// SFTP drive transfer.
 	a.EnableUpload = a.EnableUpload && policy.FileUpload

--- a/pkg/session/permisson.go
+++ b/pkg/session/permisson.go
@@ -1,10 +1,20 @@
 package session
 
 import (
+	"encoding/json"
 	"lion/pkg/config"
 
 	"github.com/jumpserver-dev/sdk-go/model"
 )
+
+type ClipboardPolicy struct {
+	FileUpload         bool `json:"file_upload"`
+	FileDownload       bool `json:"file_download"`
+	TextCopy           bool `json:"text_copy"`
+	TextPaste          bool `json:"text_paste"`
+	TextCopyMaxLength  int  `json:"text_copy_max_length"`
+	TextPasteMaxLength int  `json:"text_paste_max_length"`
+}
 
 type ActionPermission struct {
 	EnableConnect bool `json:"enable_connect"`
@@ -15,9 +25,11 @@ type ActionPermission struct {
 	EnableUpload   bool `json:"enable_upload"`
 	EnableDownload bool `json:"enable_download"`
 	EnableShare    bool `json:"enable_share"`
+
+	ClipboardPolicy ClipboardPolicy `json:"clipboard_policy"`
 }
 
-func NewActionPermission(perm *model.Permission, connectType string) *ActionPermission {
+func NewActionPermission(perm *model.Permission, connectType string, connectOptions model.ConnectOptions) *ActionPermission {
 	action := ActionPermission{
 		EnableConnect:  perm.EnableConnect(),
 		EnableCopy:     perm.EnableCopy(),
@@ -25,6 +37,12 @@ func NewActionPermission(perm *model.Permission, connectType string) *ActionPerm
 		EnableUpload:   perm.EnableUpload(),
 		EnableDownload: perm.EnableDownload(),
 		EnableShare:    perm.EnableShare(),
+		ClipboardPolicy: ClipboardPolicy{
+			FileUpload:   true,
+			FileDownload: true,
+			TextCopy:     true,
+			TextPaste:    true,
+		},
 	}
 	globConfig := config.GlobalConfig
 	switch connectType {
@@ -47,5 +65,27 @@ func NewActionPermission(perm *model.Permission, connectType string) *ActionPerm
 		action.EnablePaste = false
 		action.EnableCopy = false
 	}
+	action.applyClipboardPolicy(connectOptions)
 	return &action
+}
+
+func (a *ActionPermission) applyClipboardPolicy(connectOptions model.ConnectOptions) {
+	if connectOptions.Language == "" {
+		return
+	}
+	var policy ClipboardPolicy
+	if err := json.Unmarshal([]byte(connectOptions.Language), &policy); err != nil {
+		return
+	}
+	a.ClipboardPolicy = policy
+	// SFTP drive transfer.
+	a.EnableUpload = a.EnableUpload && policy.FileUpload
+	a.EnableDownload = a.EnableDownload && policy.FileDownload
+	// Clipboard channel (text + file share one guacd channel per direction), so
+	// keep it open when either text or file transfer is allowed in that direction.
+	// Per-stream text/file enforcement is done by the clipboard policy filter.
+	// copy: server -> client (text via TextCopy, file via FileDownload)
+	a.EnableCopy = a.EnableCopy && (policy.TextCopy || policy.FileDownload)
+	// paste: client -> server (text via TextPaste, file via FileUpload)
+	a.EnablePaste = a.EnablePaste && (policy.TextPaste || policy.FileUpload)
 }

--- a/pkg/session/server.go
+++ b/pkg/session/server.go
@@ -296,7 +296,7 @@ func (s *Server) Create(ctx *gin.Context, opts ...TunnelOption) (sess TunnelSess
 	sess.ExpireInfo = opt.ExpireInfo
 	sess.Permission = &perm
 	sess.Account = opt.Account
-	sess.ActionPerm = NewActionPermission(&perm, targetType)
+	sess.ActionPerm = NewActionPermission(&perm, targetType, opt.authInfo.ConnectOptions)
 	jmsSession := model.Session{
 		ID:         sess.ID,
 		User:       sess.User.String(),

--- a/pkg/tunnel/clipboard_policy.go
+++ b/pkg/tunnel/clipboard_policy.go
@@ -1,0 +1,113 @@
+package tunnel
+
+import (
+	"encoding/base64"
+	"unicode/utf8"
+
+	"lion/pkg/guacd"
+	"lion/pkg/session"
+)
+
+type clipboardTransfer struct {
+	index     string
+	text      bool
+	allow     bool
+	maxLength int
+	size      int
+}
+
+type clipboardPolicyFilter struct {
+	perm     *session.ActionPermission
+	toClient map[string]*clipboardTransfer
+	toServer map[string]*clipboardTransfer
+}
+
+func newClipboardPolicyFilter(perm *session.ActionPermission) *clipboardPolicyFilter {
+	return &clipboardPolicyFilter{
+		perm:     perm,
+		toClient: map[string]*clipboardTransfer{},
+		toServer: map[string]*clipboardTransfer{},
+	}
+}
+
+func (f *clipboardPolicyFilter) filterToClient(instruction *guacd.Instruction) *guacd.Instruction {
+	return f.filter(instruction, f.toClient, true)
+}
+
+func (f *clipboardPolicyFilter) filterToServer(instruction *guacd.Instruction) *guacd.Instruction {
+	return f.filter(instruction, f.toServer, false)
+}
+
+// streamPolicy resolves whether a clipboard stream may pass and the max text
+// length (0 = unlimited), by direction and content type:
+//
+//	toClient  (server -> client, copy): text via TextCopy,  file via FileDownload
+//	!toClient (client -> server, paste): text via TextPaste, file via FileUpload
+func (f *clipboardPolicyFilter) streamPolicy(toClient, text bool) (bool, int) {
+	p := f.perm.ClipboardPolicy
+	if toClient {
+		if text {
+			return f.perm.EnableCopy && p.TextCopy, p.TextCopyMaxLength
+		}
+		return f.perm.EnableCopy && p.FileDownload, 0
+	}
+	if text {
+		return f.perm.EnablePaste && p.TextPaste, p.TextPasteMaxLength
+	}
+	return f.perm.EnablePaste && p.FileUpload, 0
+}
+
+func (f *clipboardPolicyFilter) filter(instruction *guacd.Instruction, transfers map[string]*clipboardTransfer, toClient bool) *guacd.Instruction {
+	if f == nil || f.perm == nil || instruction == nil {
+		return instruction
+	}
+	switch instruction.Opcode {
+	case guacd.InstructionStreamingClipboard:
+		if len(instruction.Args) < 2 {
+			return instruction
+		}
+		text := instruction.Args[1] == "text/plain"
+		allow, maxLength := f.streamPolicy(toClient, text)
+		transfer := &clipboardTransfer{
+			index:     instruction.Args[0],
+			text:      text,
+			allow:     allow,
+			maxLength: maxLength,
+		}
+		transfers[transfer.index] = transfer
+		if !transfer.allow {
+			return nil
+		}
+	case guacd.InstructionStreamingBlob:
+		if len(instruction.Args) < 2 {
+			return instruction
+		}
+		transfer := transfers[instruction.Args[0]]
+		if transfer == nil {
+			return instruction
+		}
+		if !transfer.allow {
+			return nil
+		}
+		if transfer.text && transfer.maxLength > 0 {
+			blob, err := base64.StdEncoding.DecodeString(instruction.Args[1])
+			if err != nil {
+				return nil
+			}
+			transfer.size += utf8.RuneCount(blob)
+			if transfer.size > transfer.maxLength {
+				transfer.allow = false
+				return nil
+			}
+		}
+	case guacd.InstructionStreamingEnd:
+		if len(instruction.Args) > 0 {
+			transfer := transfers[instruction.Args[0]]
+			delete(transfers, instruction.Args[0])
+			if transfer != nil && !transfer.allow {
+				return nil
+			}
+		}
+	}
+	return instruction
+}

--- a/pkg/tunnel/conn.go
+++ b/pkg/tunnel/conn.go
@@ -58,6 +58,8 @@ type Connection struct {
 
 	inputFilter *InputStreamInterceptingFilter
 
+	clipboardFilter *clipboardPolicyFilter
+
 	done chan struct{}
 
 	traceLock sync.Mutex
@@ -114,6 +116,12 @@ func (t *Connection) readTunnelInstruction() (*guacd.Instruction, error) {
 		}
 		if t.outputFilter != nil {
 			newInstruction = t.outputFilter.Filter(newInstruction)
+			if newInstruction == nil {
+				continue
+			}
+		}
+		if t.clipboardFilter != nil {
+			newInstruction = t.clipboardFilter.filterToClient(newInstruction)
 			if newInstruction == nil {
 				continue
 			}
@@ -291,6 +299,13 @@ func (t *Connection) Run(ctx *gin.Context) (err error) {
 					case activeChan <- struct{}{}:
 					default:
 					}
+				}
+				if t.clipboardFilter != nil {
+					filtered := t.clipboardFilter.filterToServer(&ret)
+					if filtered == nil {
+						continue
+					}
+					message = []byte(filtered.String())
 				}
 			} else {
 				logger.Errorf("Session[%s] parse instruction err %s", t, err)

--- a/pkg/tunnel/server.go
+++ b/pkg/tunnel/server.go
@@ -233,6 +233,7 @@ func (g *GuacamoleTunnelServer) Connect(ctx *gin.Context) {
 	}
 	conn.outputFilter = &outFilter
 	conn.inputFilter = &inputFilter
+	conn.clipboardFilter = newClipboardPolicyFilter(tunnelSession.ActionPerm)
 	logger.Infof("Session[%s] connect success", sessionId)
 	g.Cache.Add(&conn)
 	replayRecorder := &ReplayRecorder{


### PR DESCRIPTION
为资产授权增加更细粒度的剪贴板权限控制，覆盖 RDP/VNC 图形会话：可分别管控文件上行 / 文件下行 / 字符串复制 / 字符串粘贴，并对复制、粘贴设置字符数上限（0 表示不限制）。策略从后端配置、经连接令牌下发、在图形代理逐流强制执行，前端提供独立的编辑入口。涉及 jumpserver、lion、lina 三个仓库。

- 解析连接选项中的剪贴板策略（ClipboardPolicy），无策略或解析失败时回退为全允许。
- ActionPermission 应用策略：SFTP 传输按文件上行/下行收敛；剪贴板通道（文本与文件共用一条 guacd 通道）在该方向「文本或文件任一允许」时保持开启，细粒度区分交给过滤器。
- 新增 clipboardPolicyFilter：按 guacd 流的 MIME 类型分流——文件流 按文件上行/下行放行，文本流按复制/粘贴放行并按字符数上限截断；与 inputFilter/outputFilter在同一处装配，构造即就绪。