### PR TITLE
perf: set timezone based on TZ environment variable

### DIFF
--- a/s6-overlay/cont-init.d/10-lion-init
+++ b/s6-overlay/cont-init.d/10-lion-init
@@ -9,6 +9,11 @@ if [ -n "${CORE_HOST:-}" ]; then
     done
 fi
 
+# Set timezone according to the TZ environment variable, if it is set and valid
+if [ -n "${TZ:-}" ] && [ -e "/usr/share/zoneinfo/${TZ}" ]; then
+    ln -sf "/usr/share/zoneinfo/${TZ}" /etc/localtime
+fi
+
 mkdir -p /opt/lion/data/logs/guacd
 
 if [ -e /opt/lion/data/logs/guacd.log ] || [ -L /opt/lion/data/logs/guacd.log ]; then


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GUACAMOLE-2189
因为 Guacamole 自身问题，无法通过参数传递 timezone 信息，RDP 连接固定从 /etc/localtime 获取时区。
该 PR 通过修改容器初始化脚本，通过配置的 TZ 环境变量设置 /etc/localtime，允许用户指定特定的时区。