### PR TITLE
fix: keep zoomed VNC viewport scrollable from the left

### DIFF
--- a/ui/src/views/ConnectView.vue
+++ b/ui/src/views/ConnectView.vue
@@ -416,8 +416,10 @@ const shouldEnableScroll = ref(false);
       id="display"
       v-show="!loading"
       :class="[
-        'w-screen h-screen flex justify-center relative',
-        shouldEnableScroll ? 'overflow-auto' : 'overflow-hidden',
+        'w-screen h-screen flex relative',
+        shouldEnableScroll
+          ? 'overflow-auto justify-start items-start'
+          : 'overflow-hidden justify-center',
       ]"
     ></div>
     <Osk v-if="showOsk" :keyboard="keyboardLayout" @keyboard-change="handleScreenKeyboard" />


### PR DESCRIPTION
修复多屏幕 VNC 时左侧被截断问题